### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sheu888/b79ecf96-26e7-4690-b05d-0b67fa9cf4ad/5b92fae3-c2b7-45cc-860d-f10a8602f8a4/_apis/work/boardbadge/39a11075-5368-4c3d-b00d-7394be1cf7d2)](https://dev.azure.com/sheu888/b79ecf96-26e7-4690-b05d-0b67fa9cf4ad/_boards/board/t/5b92fae3-c2b7-45cc-860d-f10a8602f8a4/Microsoft.RequirementCategory)
 ## Welcome to "Hello World" with GitHub Actions
 
 This course will walk you through writing your first action and using it with a workflow file. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sheu888/b79ecf96-26e7-4690-b05d-0b67fa9cf4ad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.